### PR TITLE
Fix not precedence

### DIFF
--- a/src/model/evaluator/createSemantics.ts
+++ b/src/model/evaluator/createSemantics.ts
@@ -32,7 +32,7 @@ export function createSemantics(
       return left.evaluate() && right.evaluate();
     },
     XorExp: function(left, _op, right) {
-      return left.evaluate() != right.evaluate();
+      return left.evaluate() !== right.evaluate();
     },
     ParenExp: function(_open, exp, _close) {
       return exp.evaluate();

--- a/src/model/evaluator/createSemantics.ts
+++ b/src/model/evaluator/createSemantics.ts
@@ -32,7 +32,7 @@ export function createSemantics(
       return left.evaluate() && right.evaluate();
     },
     XorExp: function(left, _op, right) {
-      return left.evaluate() ^ right.evaluate();
+      return left.evaluate() != right.evaluate();
     },
     ParenExp: function(_open, exp, _close) {
       return exp.evaluate();

--- a/src/model/grammar/grammarRules.ts
+++ b/src/model/grammar/grammarRules.ts
@@ -1,16 +1,19 @@
 export const grammarRules = `
 Truth {
   Exp
-    = NotExp
-    | OrExp
+    = OrExp
     | AndExp
     | XorExp
+    | PriExp
+
+  PriExp
+    = NotExp
     | ParenExp
     | ident
        
   NotExp
-    = "not " Exp
-    | "NOT " Exp
+    = "not " PriExp
+    | "NOT " PriExp
   
   OrExp
     = Exp "or " Exp

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -3,17 +3,23 @@ import { evaluate } from '../model/evaluator/evaluate';
 import { parse } from '../model/parser';
 
 describe('simple query permutation tests', () => {
-  it('generates correct query permutations for "p and q"', () => {
-    const expectedResult: QueryPermutation[] = 
-      buildExpectedResultFromTable([
+  const testCases = [
+    {
+      expression:'p and q', 
+      truthTable: [
           ['p', 'q'],
           [false, false, false],
           [false, true, false],
           [true, false, false],
           [true, true, true]
-        ]);
-
-    expect(evaluate(parse('p and q'))).toStrictEqual(expectedResult);
+        ]
+    }
+  ]
+  testCases.forEach((testCase) => {
+    it('generates correct query permutations for ' + testCase.expression, () => {
+      const expectedResult = buildExpectedResultFromTable(testCase.truthTable);
+      expect(evaluate(parse(testCase.expression))).toStrictEqual(expectedResult);
+    });
   });
 });
 

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -14,17 +14,16 @@ describe('simple query permutation tests', () => {
         [true, true, true]
       ]
     },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'not p and q',
-    //   truthTable: [
-    //     ['p', 'q'],
-    //     [false, false, false],
-    //     [false, true, true],
-    //     [true, false, false],
-    //     [true, true, false]
-    //   ]
-    // },
+    {
+      expression: 'not p and q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, false],
+        [false, true, true],
+        [true, false, false],
+        [true, true, false]
+      ]
+    },
     {
       expression: 'p or q',
       truthTable: [
@@ -65,28 +64,26 @@ describe('simple query permutation tests', () => {
         [true, true, true]
       ]
     },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'not p or q',
-    //   truthTable: [
-    //     ['p', 'q'],
-    //     [false, false, true],
-    //     [false, true, true],
-    //     [true, false, false],
-    //     [true, true, true]
-    //   ]
-    // },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'not p and not q',
-    //   truthTable: [
-    //     ['p', 'q'],
-    //     [false, false, true],
-    //     [false, true, false],
-    //     [true, false, false],
-    //     [true, true, false]
-    //   ]
-    // },
+    {
+      expression: 'not p or q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, true],
+        [false, true, true],
+        [true, false, false],
+        [true, true, true]
+      ]
+    },
+    {
+      expression: 'not p and not q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, true],
+        [false, true, false],
+        [true, false, false],
+        [true, true, false]
+      ]
+    },
     {
       expression: 'p and q and s',
       truthTable: [
@@ -115,21 +112,20 @@ describe('simple query permutation tests', () => {
         [true, true, true, false]
       ]
     },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'p and not q and s',
-    //   truthTable: [
-    //     ['p', 'q', 's'],
-    //     [false, false, false, false],
-    //     [false, false, true, false],
-    //     [false, true, false, false],
-    //     [false, true, true, false],
-    //     [true, false, false, false],
-    //     [true, false, true, true],
-    //     [true, true, false, false],
-    //     [true, true, true, false]
-    //   ]
-    // },
+    {
+      expression: 'p and not q and s',
+      truthTable: [
+        ['p', 'q', 's'],
+        [false, false, false, false],
+        [false, false, true, false],
+        [false, true, false, false],
+        [false, true, true, false],
+        [true, false, false, false],
+        [true, false, true, true],
+        [true, true, false, false],
+        [true, true, true, false]
+      ]
+    },
     {
       expression: 'p and not (q and s)',
       truthTable: [
@@ -144,21 +140,20 @@ describe('simple query permutation tests', () => {
         [true, true, true, false]
       ]
     },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'not p and q and s',
-    //   truthTable: [
-    //     ['p', 'q', 's'],
-    //     [false, false, false, false],
-    //     [false, false, true, false],
-    //     [false, true, false, false],
-    //     [false, true, true, true],
-    //     [true, false, false, false],
-    //     [true, false, true, false],
-    //     [true, true, false, false],
-    //     [true, true, true, false]
-    //   ]
-    // },
+    {
+      expression: 'not p and q and s',
+      truthTable: [
+        ['p', 'q', 's'],
+        [false, false, false, false],
+        [false, false, true, false],
+        [false, true, false, false],
+        [false, true, true, true],
+        [true, false, false, false],
+        [true, false, true, false],
+        [true, true, false, false],
+        [true, true, true, false]
+      ]
+    },
   ]
   testCases.forEach((testCase) => {
     it('generates correct query permutations for ' + testCase.expression, () => {

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -3,17 +3,163 @@ import { evaluate } from '../model/evaluator/evaluate';
 import { parse } from '../model/parser';
 
 describe('simple query permutation tests', () => {
-  const testCases = [
+  const testCases: {expression: string, truthTable: any[]}[] = [
     {
-      expression:'p and q', 
+      expression: 'p and q', 
       truthTable: [
-          ['p', 'q'],
-          [false, false, false],
-          [false, true, false],
-          [true, false, false],
-          [true, true, true]
-        ]
-    }
+        ['p', 'q'],
+        [false, false, false],
+        [false, true, false],
+        [true, false, false],
+        [true, true, true]
+      ]
+    },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'not p and q',
+    //   truthTable: [
+    //     ['p', 'q'],
+    //     [false, false, false],
+    //     [false, true, true],
+    //     [true, false, false],
+    //     [true, true, false]
+    //   ]
+    // },
+    {
+      expression: 'p or q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, false],
+        [false, true, true],
+        [true, false, true],
+        [true, true, true]
+      ]
+    },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'p xor q',
+    //   truthTable: [
+    //     ['p', 'q'],
+    //     [false, false, false],
+    //     [false, true, true],
+    //     [true, false, true],
+    //     [true, true, false]
+    //   ]
+    // },
+    {
+      expression: 'p and not q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, false],
+        [false, true, false],
+        [true, false, true],
+        [true, true, false]
+      ]
+    },
+    {
+      expression: 'p or not q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, true],
+        [false, true, false],
+        [true, false, true],
+        [true, true, true]
+      ]
+    },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'not p or q',
+    //   truthTable: [
+    //     ['p', 'q'],
+    //     [false, false, true],
+    //     [false, true, true],
+    //     [true, false, false],
+    //     [true, true, true]
+    //   ]
+    // },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'not p and not q',
+    //   truthTable: [
+    //     ['p', 'q'],
+    //     [false, false, true],
+    //     [false, true, false],
+    //     [true, false, false],
+    //     [true, true, false]
+    //   ]
+    // },
+    {
+      expression: 'p and q and s',
+      truthTable: [
+        ['p', 'q', 's'],
+        [false, false, false, false],
+        [false, false, true, false],
+        [false, true, false, false],
+        [false, true, true, false],
+        [true, false, false, false],
+        [true, false, true, false],
+        [true, true, false, false],
+        [true, true, true, true]
+      ]
+    },
+    {
+      expression: 'p and q and not s',
+      truthTable: [
+        ['p', 'q', 's'],
+        [false, false, false, false],
+        [false, false, true, false],
+        [false, true, false, false],
+        [false, true, true, false],
+        [true, false, false, false],
+        [true, false, true, false],
+        [true, true, false, true],
+        [true, true, true, false]
+      ]
+    },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'p and not q and s',
+    //   truthTable: [
+    //     ['p', 'q', 's'],
+    //     [false, false, false, false],
+    //     [false, false, true, false],
+    //     [false, true, false, false],
+    //     [false, true, true, false],
+    //     [true, false, false, false],
+    //     [true, false, true, true],
+    //     [true, true, false, false],
+    //     [true, true, true, false]
+    //   ]
+    // },
+    {
+      expression: 'p and not (q and s)',
+      truthTable: [
+        ['p', 'q', 's'],
+        [false, false, false, false],
+        [false, false, true, false],
+        [false, true, false, false],
+        [false, true, true, false],
+        [true, false, false, true],
+        [true, false, true, true],
+        [true, true, false, true],
+        [true, true, true, false]
+      ]
+    },
+    // TODO: re-enable after fix
+    // {
+    //   expression: 'not p and q and s',
+    //   truthTable: [
+    //     ['p', 'q', 's'],
+    //     [false, false, false, false],
+    //     [false, false, true, false],
+    //     [false, true, false, false],
+    //     [false, true, true, true],
+    //     [true, false, false, false],
+    //     [true, false, true, false],
+    //     [true, true, false, false],
+    //     [true, true, true, false]
+    //   ]
+    // },
   ]
   testCases.forEach((testCase) => {
     it('generates correct query permutations for ' + testCase.expression, () => {
@@ -41,14 +187,14 @@ describe('generates correct number of permutations', () => {
  * Helper function for building expected results more concisely
  * @param table - A 2-dimensional array. 
  *   First ("header") row is the list of variables of length n. 
- *   Remaining n^2 rows (of length n+1) are the expected boolean values of the truth table
+ *   Remaining 2^n rows (of length n+1) are the expected boolean values of the truth table
  * @returns The expected return from the evaluate function
 */
 function buildExpectedResultFromTable(table: any[][]): QueryPermutation[] {
   const result: QueryPermutation[] = [];
   const variableNames: string[] = table[0];
-  assert(table.length-1 === Math.pow(variableNames.length,2), 
-    "Expected number of rows to equal the square of the number of variables");
+  assert(table.length-1 === Math.pow(2, variableNames.length), 
+    "Expected number of rows to equal 2 ^ the number of variables");
   for (let row of table.slice(1)) {
     const expressionOutput: boolean = row[row.length-1];
     const expressionInputs: boolean[] = row.slice(0,row.length-1);

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -4,24 +4,14 @@ import { parse } from '../model/parser';
 
 describe('simple query permutation tests', () => {
   it('generates correct query permutations for "p and q"', () => {
-    const expectedResult: QueryPermutation[] = [
-      {
-        queryParameters: new Map<string, boolean>([['p', false], ['q', false]]),
-        value: false,
-      },
-      {
-        queryParameters: new Map<string, boolean>([['p', false], ['q', true]]),
-        value: false,
-      },
-      {
-        queryParameters: new Map<string, boolean>([['p', true], ['q', false]]),
-        value: false,
-      },
-      {
-        queryParameters: new Map<string, boolean>([['p', true], ['q', true]]),
-        value: true,
-      },
-    ];
+    const expectedResult: QueryPermutation[] = 
+      buildExpectedResultFromTable([
+          ['p', 'q'],
+          [false, false, false],
+          [false, true, false],
+          [true, false, false],
+          [true, true, true]
+        ]);
 
     expect(evaluate(parse('p and q'))).toStrictEqual(expectedResult);
   });
@@ -40,3 +30,38 @@ describe('generates correct number of permutations', () => {
     expect(evaluate(parse('p and q or r xor s or p or q'))).toHaveLength(16);
   });
 });
+
+/**
+ * Helper function for building expected results more concisely
+ * @param table - A 2-dimensional array. 
+ *   First ("header") row is the list of variables of length n. 
+ *   Remaining n^2 rows (of length n+1) are the expected boolean values of the truth table
+ * @returns The expected return from the evaluate function
+*/
+function buildExpectedResultFromTable(table: any[][]): QueryPermutation[] {
+  const result: QueryPermutation[] = [];
+  const variableNames: string[] = table[0];
+  assert(table.length-1 === Math.pow(variableNames.length,2), 
+    "Expected number of rows to equal the square of the number of variables");
+  for (let row of table.slice(1)) {
+    const expressionOutput: boolean = row[row.length-1];
+    const expressionInputs: boolean[] = row.slice(0,row.length-1);
+    assert(variableNames.length === expressionInputs.length, 
+      "Expected number of variables to equal number of inputs.");
+    const mapValues: [string, boolean][] = []
+    for (let i = 0; i < variableNames.length; i++) {
+      mapValues.push([variableNames[i], expressionInputs[i]]);
+    }
+    result.push({
+      queryParameters: new Map<string, boolean>(mapValues),
+      value: row[row.length-1]
+    })
+  }
+  return result;
+}
+
+function assert(condition: boolean, message: string) {
+    if (!condition) {
+        throw new Error('Assertion failed: ' + message);
+    }
+}

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -35,17 +35,16 @@ describe('simple query permutation tests', () => {
         [true, true, true]
       ]
     },
-    // TODO: re-enable after fix
-    // {
-    //   expression: 'p xor q',
-    //   truthTable: [
-    //     ['p', 'q'],
-    //     [false, false, false],
-    //     [false, true, true],
-    //     [true, false, true],
-    //     [true, true, false]
-    //   ]
-    // },
+    {
+      expression: 'p xor q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, false],
+        [false, true, true],
+        [true, false, true],
+        [true, true, false]
+      ]
+    },
     {
       expression: 'p and not q',
       truthTable: [

--- a/src/tests/evaluate.test.ts
+++ b/src/tests/evaluate.test.ts
@@ -75,6 +75,16 @@ describe('simple query permutation tests', () => {
       ]
     },
     {
+      expression: 'not p xor q',
+      truthTable: [
+        ['p', 'q'],
+        [false, false, true],
+        [false, true, false],
+        [true, false, false],
+        [true, true, true]
+      ]
+    },
+    {
       expression: 'not p and not q',
       truthTable: [
         ['p', 'q'],

--- a/src/view/truthTable/TruthTableRow.tsx
+++ b/src/view/truthTable/TruthTableRow.tsx
@@ -4,8 +4,6 @@ import { QueryPermutation } from '../../model';
 import { TruthTableCell } from './TruthTableCell';
 import uuid from 'uuid';
 
-const resultString = 'Result';
-
 interface TruthTableRowProps {
   row: QueryPermutation;
 }


### PR DESCRIPTION
Fixes #25.  

- Fixed the grammar so that "not" can only operate on identity, parentheses, and other not expressions
- Added a bunch of tests
- Minor tweak to the XOR - changed it to use `!==` so that we get true/false instead of 0/1 (more testable)